### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Directory Lister is the easiest way to expose the contents of any web-accessible
 * Official app website: <https://www.directorylister.com/>
 * Official admin documentation: <https://docs.directorylister.com/>
 * Upstream app code repository: <https://github.com/DirectoryLister/DirectoryLister>
-* YunoHost documentation for this app: <https://yunohost.org/app_directorylister>
+* YunoHost Store: <https://apps.yunohost.org/app/directorylister>
 * Report a bug: <https://github.com/YunoHost-Apps/directorylister_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -42,7 +42,7 @@ Directory Lister est le moyen le plus simple d'exposer le contenu de n'importe q
 * Site officiel de l’app : <https://www.directorylister.com/>
 * Documentation officielle de l’admin : <https://docs.directorylister.com/>
 * Dépôt de code officiel de l’app : <https://github.com/DirectoryLister/DirectoryLister>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_directorylister>
+* YunoHost Store: <https://apps.yunohost.org/app/directorylister>
 * Signaler un bug : <https://github.com/YunoHost-Apps/directorylister_ynh/issues>
 
 ## Informations pour les développeurs

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir" --keep=".env"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep=".env"
 fi
 
 chown -R $app:www-data "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```