### PR TITLE
Add SFTP access to the app

### DIFF
--- a/conf/directorylister.service
+++ b/conf/directorylister.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Mount directorylister data on install 
+
+[Mount]
+What=__DATA_DIR__/data
+Where=__INSTALL_DIR__
+Type=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,7 +2,7 @@
 location __PATH__/ {
 
   # Path to source
-  alias __INSTALL_DIR__/;
+  alias __INSTALL_DIR__/www/;
 
   index index.php;
 

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,7 +1,7 @@
 version = "1.0"
 
 [main]
-name = "My Webapp configuration"
+name = "SFTP configuration"
 
     [main.sftp]
     name.en = "SFTP access"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,23 @@
+version = "1.0"
+
+[main]
+name = "My Webapp configuration"
+
+    [main.sftp]
+    name.en = "SFTP access"
+    name.fr = "Accès SFTP"
+
+        [main.sftp.with_sftp]
+        ask.en = "Do you need a SFTP access?"
+        ask.fr = "Avez-vous besoin d'un accès SFTP ?"
+        type = "boolean"
+        default = true
+
+        [main.sftp.password]
+        ask.en = "Set a password for the SFTP access"
+        ask.fr = "Définir un mot de passe pour l’accès SFTP"
+        type = "password"
+        optional = true
+        visible = "with_sftp"
+        help.en = "If a password already exist, leave blank and it will not be replaced."
+        help.fr = "Si un mot de passe existe déjà, laissez vide et il ne sera pas remplacé."

--- a/manifest.toml
+++ b/manifest.toml
@@ -77,7 +77,11 @@ ram.runtime = "50M"
 
     [resources.install_dir]
     group = "www-data:r-x"
-
+    
+    [resources.data_dir]
+    owner = "__APP__:rwx"
+    group = "www-data:rwx"
+    
     [resources.permissions]
     main.url = "/"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -51,6 +51,16 @@ ram.runtime = "50M"
     choices = ["fr", "en"]
     default = "fr"
 
+    [install.with_sftp]
+    ask.en = "Do you need a SFTP access?"
+    ask.fr = "Avez-vous besoin d'un accès SFTP ?"
+    type = "boolean"
+    default = true
+
+    [install.password]
+    type = "password"
+    optional = true
+    
 [resources]
 
     [resources.sources]

--- a/manifest.toml
+++ b/manifest.toml
@@ -78,10 +78,6 @@ ram.runtime = "50M"
     [resources.install_dir]
     group = "www-data:r-x"
 
-    [resources.data_dir]
-    owner = "__APP__:rwx"
-    group = "www-data:rwx"
-    
     [resources.permissions]
     main.url = "/"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -78,10 +78,6 @@ ram.runtime = "50M"
     [resources.install_dir]
     group = "www-data:r-x"
     
-    [resources.data_dir]
-    owner = "__APP__:rwx"
-    group = "www-data:rwx"
-    
     [resources.permissions]
     main.url = "/"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -77,6 +77,10 @@ ram.runtime = "50M"
 
     [resources.install_dir]
     group = "www-data:r-x"
+
+    [resources.data_dir]
+    owner = "__APP__:rwx"
+    group = "www-data:rwx"
     
     [resources.permissions]
     main.url = "/"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,5 +1,124 @@
 #!/bin/bash
 
 #=================================================
-# COMMON VARIABLES AND CUSTOM HELPERS
+# COMMON VARIABLES
 #=================================================
+
+#=================================================
+# EXPERIMENTAL HELPERS
+#=================================================
+
+ynh_maintenance_mode_ON () {
+	# Load value of $path and $domain from the config if their not set
+	if [ -z $path ]; then
+		path=$(ynh_app_setting_get $app path)
+	fi
+	if [ -z $domain ]; then
+		domain=$(ynh_app_setting_get $app domain)
+	fi
+
+	mkdir -p /var/www/html/
+	
+	# Create an html to serve as maintenance notice
+	echo "<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="3">
+<title>Your app $app is currently under maintenance!</title>
+<style>
+	body {
+		width: 70em;
+		margin: 0 auto;
+	}
+</style>
+</head>
+<body>
+<h1>Your app $app is currently under maintenance!</h1>
+<p>This app has been put under maintenance by your administrator at $(date)</p>
+<p>Please wait until the maintenance operation is done. This page will be reloaded as soon as your app will be back.</p>
+
+</body>
+</html>" > "/var/www/html/maintenance.$app.html"
+
+	# Create a new nginx config file to redirect all access to the app to the maintenance notice instead.
+	echo "# All request to the app will be redirected to ${path}_maintenance and fall on the maintenance notice
+rewrite ^${path}/(.*)$ ${path}_maintenance/? redirect;
+# Use another location, to not be in conflict with the original config file
+location ${path}_maintenance/ {
+alias /var/www/html/ ;
+
+try_files maintenance.$app.html =503;
+
+# Include SSOWAT user panel.
+include conf.d/yunohost_panel.conf.inc;
+}" > "/etc/nginx/conf.d/$domain.d/maintenance.$app.conf"
+
+	# The current config file will redirect all requests to the root of the app.
+	# To keep the full path, we can use the following rewrite rule:
+	# 	rewrite ^${path}/(.*)$ ${path}_maintenance/\$1? redirect;
+	# The difference will be in the $1 at the end, which keep the following queries.
+	# But, if it works perfectly for a html request, there's an issue with any php files.
+	# This files are treated as simple files, and will be downloaded by the browser.
+	# Would be really be nice to be able to fix that issue. So that, when the page is reloaded after the maintenance, the user will be redirected to the real page he was.
+
+	systemctl reload nginx
+}
+
+ynh_maintenance_mode_OFF () {
+	# Load value of $path and $domain from the config if their not set
+	if [ -z $path ]; then
+		path=$(ynh_app_setting_get $app path)
+	fi
+	if [ -z $domain ]; then
+		domain=$(ynh_app_setting_get $app domain)
+	fi
+
+	# Rewrite the nginx config file to redirect from ${path}_maintenance to the real url of the app.
+	echo "rewrite ^${path}_maintenance/(.*)$ ${path}/\$1 redirect;" > "/etc/nginx/conf.d/$domain.d/maintenance.$app.conf"
+	systemctl reload nginx
+
+	# Sleep 4 seconds to let the browser reload the pages and redirect the user to the app.
+	sleep 4
+
+	# Then remove the temporary files used for the maintenance.
+	rm "/var/www/html/maintenance.$app.html"
+	rm "/etc/nginx/conf.d/$domain.d/maintenance.$app.conf"
+
+	systemctl reload nginx
+}
+
+
+ynh_system_user_add_group() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=uhs
+    local -A args_array=([u]=username= [g]=groups=)
+    local username
+    local groups
+
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    groups="${groups:-}"
+
+	local group
+	for group in $groups; do
+		usermod -a -G "$group" "$username"
+	done
+}
+
+
+ynh_system_user_del_group() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=uhs
+    local -A args_array=([u]=username= [g]=groups=)
+    local username
+    local groups
+
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    groups="${groups:-}"
+
+	local group
+	for group in $groups; do
+		gpasswd -d "$username" "$group"
+	done
+}

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#=================================================
+# GENERIC STARTING
+#=================================================
+# IMPORT GENERIC HELPERS
+#=================================================
+
+source _common.sh
+source /usr/share/yunohost/helpers
+
+ynh_abort_if_errors
+
+#=================================================
+# RETRIEVE ARGUMENTS
+#=================================================
+
+install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
+domain=$(ynh_app_setting_get --app=$app --key=domain)
+path=$(ynh_app_setting_get --app=$app --key=path)
+
+#=================================================
+# SPECIFIC SETTERS FOR TOML SHORT KEYS
+#=================================================
+
+set__password() {
+    if [ ! "$password" == "" ]
+    then
+        ynh_app_setting_set --app=$app --key=password --value="$password"
+    fi
+}
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+
+ynh_app_config_validate() {
+    _ynh_app_config_validate
+
+    if [ "${changed[with_sftp]}" == "true" ] && [ $with_sftp -eq 1 ] && [ "$password" == "" ]
+    then
+        ynh_die --message="You need to set a password to enable SFTP"
+    fi
+}
+
+ynh_app_config_apply() {
+    _ynh_app_config_apply
+
+    if [ "${changed[with_sftp]}" == "true" ] && [ $with_sftp -eq 1 ]
+    then
+        ynh_system_user_add_group --username=$app --groups="sftp.app"
+
+        if [ ! "$password" == "" ]
+        then
+            chpasswd <<< "${app}:${password}"
+        fi
+    elif [ "${changed[with_sftp]}" == "true" ] && [ $with_sftp -eq 0 ]
+    then
+        ynh_system_user_del_group --username=$app --groups="sftp.app"
+    fi
+    
+    if [ "${changed[password]}" == "true" ] && [ ! "$password" == "" ]
+    then
+        chpasswd <<< "${app}:${password}"
+    fi
+}
+
+ynh_app_config_run $1

--- a/scripts/install
+++ b/scripts/install
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$install_dir" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$data_dir" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -39,13 +39,14 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-chown -R $app:www-data "$install_dir"
+mkdir $data_dir/data
+chown -R $app:www-data "$data_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections
-chown root:root "$install_dir"
-setfacl -m g:$app:r-x "$install_dir"
-setfacl -m g:www-data:r-x "$install_dir"
-chmod 750 "$install_dir"
+chown root:root "$data_dir"
+setfacl -m g:$app:r-x "$data_dir"
+setfacl -m g:www-data:r-x "$data_dir"
+chmod 750 "$data_dir"
 
 #=================================================
 # ADD A CONFIGURATION
@@ -53,6 +54,8 @@ chmod 750 "$install_dir"
 ynh_script_progression "Adding $app's configuration..."
 
 ynh_config_add --template=".env.example" --destination="$install_dir/.env"
+
+ynh_replace_string --match_string="'open_basedir', __DIR__" --replace_string="'open_basedir', __DIR__, $data_dir/data" --target_file="$install_dir/index.php"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -39,7 +39,7 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-mkdir $data_dir/data
+mkdir -p $data_dir/data
 chown -R $app:www-data "$data_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections

--- a/scripts/install
+++ b/scripts/install
@@ -13,6 +13,7 @@ ynh_app_setting_set --key=php_memory_limit --value=256M
 
 password=$YNH_APP_ARG_PASSWORD
 ssh_port=$(grep "^Port" /etc/ssh/sshd_config | awk '{print $2}')
+ynh_app_setting_set --app=$app --key=password --value=$password
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/install
+++ b/scripts/install
@@ -64,7 +64,7 @@ ynh_config_add_phpfpm
 
 ynh_config_add_nginx
 
-ynh_add_systemd_config --service="$app-mount" --template="directorylister.service"
+ynh_config_add_systemd --service="$app-mount" --template="../conf/directorylister.service"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_script_progression "Adding $app's configuration..."
 
 ynh_config_add --template=".env.example" --destination="$install_dir/.env"
 
-ynh_replace_string --match_string="'open_basedir', __DIR__" --replace_string="'open_basedir', __DIR__, $data_dir/data" --target_file="$install_dir/index.php"
+ynh_replace --match="'open_basedir', __DIR__" --replace="'open_basedir', __DIR__, $data_dir/data" --file="$install_dir/index.php"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -22,7 +22,7 @@ ynh_app_setting_set --app=$app --key=password --value=$password
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir/www"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$data_dir" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$install_dir" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -39,21 +39,20 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-mkdir -p $data_dir/data
-chown -R $app:www-data "$data_dir"
+chown -R $app:www-data "$install_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections
-chown root:root "$data_dir"
-setfacl -m g:$app:r-x "$data_dir"
-setfacl -m g:www-data:r-x "$data_dir"
-chmod 750 "$data_dir"
+chown root:root "$install_dir"
+setfacl -m g:$app:r-x "$install_dir"
+setfacl -m g:www-data:r-x "$install_dir"
+chmod 750 "$install_dir"
 
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression "Adding $app's configuration..."
 
-ynh_config_add --template=".env.example" --destination="$install_dir/.env"
+ynh_config_add --template=".env.example" --destination="$install_dir/www/.env"
 
 #=================================================
 # SYSTEM CONFIGURATION
@@ -63,8 +62,6 @@ ynh_script_progression "Adding system configurations related to $app..."
 ynh_config_add_phpfpm
 
 ynh_config_add_nginx
-
-ynh_config_add_systemd --service="$app-mount" --template="../conf/directorylister.service"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -22,7 +22,7 @@ ynh_app_setting_set --app=$app --key=password --value=$password
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-ynh_setup_source --dest_dir="$install_dir/www"
+ynh_setup_source --dest_dir="$install_dir"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$install_dir/www" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$data_dir" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -39,13 +39,14 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-chown -R $app:www-data "$install_dir"
+mkdir $data_dir/data
+chown -R $app:www-data "$data_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections
-chown root:root "$install_dir"
-setfacl -m g:$app:r-x "$install_dir"
-setfacl -m g:www-data:r-x "$install_dir"
-chmod 750 "$install_dir"
+chown root:root "$data_dir"
+setfacl -m g:$app:r-x "$data_dir"
+setfacl -m g:www-data:r-x "$data_dir"
+chmod 750 "$data_dir"
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -9,9 +9,9 @@ source /usr/share/yunohost/helpers
 
 [ $with_sftp -eq 0 ] || [ "$password" != "" ] || ynh_die --message="You need to set a password to enable SFTP"
 
-ynh_app_setting_set --key=php_upload_max_filesize --value=256M
+ynh_app_setting_set --key=php_upload_max_filesize --value=2G
 
-ynh_app_setting_set --key=php_memory_limit --value=256M
+ynh_app_setting_set --key=php_memory_limit --value=2G
 
 password=$YNH_APP_ARG_PASSWORD
 ssh_port=$(grep "^Port" /etc/ssh/sshd_config | awk '{print $2}')

--- a/scripts/install
+++ b/scripts/install
@@ -64,6 +64,8 @@ ynh_config_add_phpfpm
 
 ynh_config_add_nginx
 
+ynh_add_systemd_config --service="$app-mount" --template="directorylister.service"
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -11,12 +11,21 @@ ynh_app_setting_set --key=php_upload_max_filesize --value=256M
 
 ynh_app_setting_set --key=php_memory_limit --value=256M
 
+password=$YNH_APP_ARG_PASSWORD
+ssh_port=$(grep "^Port" /etc/ssh/sshd_config | awk '{print $2}')
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression "Setting up source files..."
 
 ynh_setup_source --dest_dir="$install_dir"
+
+if [ $with_sftp -eq 1 ]
+then
+    # Add the password to this user
+    chpasswd <<< "${app}:${password}"
+fi
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -7,6 +7,8 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
+[ $with_sftp -eq 0 ] || [ "$password" != "" ] || ynh_die --message="You need to set a password to enable SFTP"
+
 ynh_app_setting_set --key=php_upload_max_filesize --value=256M
 
 ynh_app_setting_set --key=php_memory_limit --value=256M

--- a/scripts/install
+++ b/scripts/install
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$install_dir" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$install_dir/data" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then

--- a/scripts/install
+++ b/scripts/install
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$data_dir" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$install_dir" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -39,14 +39,14 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-mkdir $data_dir/data
-chown -R $app:www-data "$data_dir"
+mkdir $install_dir/data
+chown -R $app:www-data "$install_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections
-chown root:root "$data_dir"
-setfacl -m g:$app:r-x "$data_dir"
-setfacl -m g:www-data:r-x "$data_dir"
-chmod 750 "$data_dir"
+chown root:root "$install_dir"
+setfacl -m g:$app:r-x "$install_dir"
+setfacl -m g:www-data:r-x "$install_dir"
+chmod 750 "$install_dir"
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_script_progression "Adding $app's configuration..."
 
 ynh_config_add --template=".env.example" --destination="$install_dir/.env"
 
-ynh_replace --match="'open_basedir', __DIR__" --replace="'open_basedir', __DIR__, $data_dir/data" --file="$install_dir/index.php"
+#ynh_replace --match="'open_basedir', __DIR__" --replace="'open_basedir', __DIR__, $data_dir/data" --file="$install_dir/index.php"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -22,7 +22,7 @@ ynh_app_setting_set --app=$app --key=password --value=$password
 #=================================================
 ynh_script_progression "Setting up source files..."
 
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir/www"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -31,7 +31,7 @@ else
     groups=""
 fi
 
-    ynh_system_user_create --username=$app --home_dir="$install_dir/data" --groups="$groups"
+    ynh_system_user_create --username=$app --home_dir="$install_dir/www" --groups="$groups"
 
 if [ $with_sftp -eq 1 ]
 then
@@ -39,7 +39,6 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-mkdir $install_dir/data
 chown -R $app:www-data "$install_dir"
 # Home directory of the user needs to be owned by root to allow
 # SFTP connections
@@ -54,8 +53,6 @@ chmod 750 "$install_dir"
 ynh_script_progression "Adding $app's configuration..."
 
 ynh_config_add --template=".env.example" --destination="$install_dir/.env"
-
-#ynh_replace --match="'open_basedir', __DIR__" --replace="'open_basedir', __DIR__, $data_dir/data" --file="$install_dir/index.php"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -26,9 +26,20 @@ ynh_setup_source --dest_dir="$install_dir"
 
 if [ $with_sftp -eq 1 ]
 then
+    groups="sftp.app"
+else
+    groups=""
+fi
+
+    ynh_system_user_create --username=$app --home_dir="$install_dir" --groups="$groups"
+
+if [ $with_sftp -eq 1 ]
+then
     # Add the password to this user
     chpasswd <<< "${app}:${password}"
 fi
+
+
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -39,7 +39,13 @@ then
     chpasswd <<< "${app}:${password}"
 fi
 
-
+chown -R $app:www-data "$install_dir"
+# Home directory of the user needs to be owned by root to allow
+# SFTP connections
+chown root:root "$install_dir"
+setfacl -m g:$app:r-x "$install_dir"
+setfacl -m g:www-data:r-x "$install_dir"
+chmod 750 "$install_dir"
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,7 +16,6 @@ ynh_config_remove_nginx
 
 ynh_config_remove_phpfpm
 
-ynh_config_remove_systemd
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,6 +16,7 @@ ynh_config_remove_nginx
 
 ynh_config_remove_phpfpm
 
+ynh_config_remove_systemd
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,18 +7,22 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-ynh_app_setting_set_default --key=php_upload_max_filesize --value=256M
+ynh_app_setting_set_default --key=php_upload_max_filesize --value=2G
 
-ynh_app_setting_set_default --key=php_memory_limit --value=256M
+ynh_app_setting_set_default --key=php_memory_limit --value=2G
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_config_remove_systemd
+ynh_setup_source --dest_dir="$install_dir"
 
-ynh_setup_source --dest_dir="$install_dir/www" --keep=".env"
+mv $install_dir/index.php $install_dir/www/index.php -f
+mv $install_dir/app/ $install_dir/www/app/ -f
+mv $install_dir/directory-lister.svg $install_dir/www/directory-lister.svg -f
+mv $install_dir/LICENSE $install_dir/www/LICENSE -f
+mv $install_dir/README.md $install_dir/www/README.md -f
 
 #==============================================
 # REAPPLY SYSTEM CONFIGURATIONS
@@ -28,8 +32,6 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 ynh_config_add_phpfpm
 
 ynh_config_add_nginx
-
-ynh_config_add_systemd --service $app
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,7 +16,7 @@ ynh_app_setting_set_default --key=php_memory_limit --value=256M
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --keep=".env"
+ynh_setup_source --dest_dir="$install_dir/www" --keep=".env"
 
 #=================================================
 # UPDATE A CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,13 +16,13 @@ ynh_app_setting_set_default --key=php_memory_limit --value=2G
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir/www" --full_replace
 
-mv $install_dir/index.php $install_dir/www/index.php -f
-mv $install_dir/app/ $install_dir/www/app/ -f
-mv $install_dir/directory-lister.svg $install_dir/www/directory-lister.svg -f
-mv $install_dir/LICENSE $install_dir/www/LICENSE -f
-mv $install_dir/README.md $install_dir/www/README.md -f
+#mv $install_dir/index.php $install_dir/www/index.php -f
+#mv $install_dir/app/ $install_dir/www/app/ -f
+#mv $install_dir/directory-lister.svg $install_dir/www/directory-lister.svg -f
+#mv $install_dir/LICENSE $install_dir/www/LICENSE -f
+#mv $install_dir/README.md $install_dir/www/README.md -f
 
 #==============================================
 # REAPPLY SYSTEM CONFIGURATIONS

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,14 +16,9 @@ ynh_app_setting_set_default --key=php_memory_limit --value=256M
 #=================================================
 ynh_script_progression "Upgrading source files..."
 
+ynh_config_remove_systemd
+
 ynh_setup_source --dest_dir="$install_dir/www" --keep=".env"
-
-#=================================================
-# UPDATE A CONFIG FILE
-#=================================================
-# ynh_script_progression "Updating configuration..."
-
-# ynh_config_add --template=".env.example" --destination="$install_dir/.env"
 
 #==============================================
 # REAPPLY SYSTEM CONFIGURATIONS
@@ -33,6 +28,8 @@ ynh_script_progression "Upgrading system configurations related to $app..."
 ynh_config_add_phpfpm
 
 ynh_config_add_nginx
+
+ynh_config_add_systemd --service $app
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
@ericgaspar I hope you're doing well
I have added SFTP access to the app by copying the same code from my_webapp. I had to move the content of the app folder to a "www" subfolder because I faced permission denied for the root folder.
I also tried to add a data_dir and to mount bind it but I failed miserably.
I asked the dev if it was possible to add other locations, he told that it wasn't possible for now, he proposed a workaround but it didn't work.

With this schema, the app allows SFTP, backups include the data.
I thought about pointing to a subfolder on the multimedia/share so it would be accessible by a lot of apps, but couldn't.

I will be grateful if you could have a look at what I've added and fix what needs to be fixed as I have been interrupted more than 100 times during the process.
Thanks